### PR TITLE
Improve onvif device test tool compatibility

### DIFF
--- a/src/ServiceContext.cpp
+++ b/src/ServiceContext.cpp
@@ -197,6 +197,8 @@ trt__Capabilities *ServiceContext::getMediaServiceCapabilities(soap *soap)
 
     capabilities->StreamingCapabilities = soap_new_trt__StreamingCapabilities(soap);
     capabilities->StreamingCapabilities->RTPMulticast = soap_new_ptr(soap, false);
+    capabilities->StreamingCapabilities->RTP_USCORETCP = soap_new_ptr(soap, false);
+    capabilities->StreamingCapabilities->RTP_USCORERTSP_USCORETCP = soap_new_ptr(soap, true);
 
 
     return capabilities;
@@ -300,6 +302,7 @@ tt__Profile* StreamProfile::get_profile(struct soap *soap) const
 
     profile->Name  = name;
     profile->token = name;
+    profile->fixed = soap_new_ptr(soap, true);
 
     profile->VideoSourceConfiguration  = get_video_src_cnf(soap);
     profile->VideoEncoderConfiguration = get_video_enc_cfg(soap);

--- a/src/ServiceContext.h
+++ b/src/ServiceContext.h
@@ -31,6 +31,10 @@ class StreamProfile
         tt__Profile*     get_profile(struct soap *soap) const;
         tt__VideoSource* get_video_src(struct soap *soap) const;
 
+        tt__VideoSourceConfiguration*  get_video_src_cnf(struct soap *soap) const;
+        tt__VideoEncoderConfiguration* get_video_enc_cfg(struct soap *soap) const;
+        tt__PTZConfiguration*          get_ptz_cfg(struct soap *soap) const;
+
 
 
         //methods for parsing opt from cmd
@@ -60,11 +64,6 @@ class StreamProfile
 
 
         std::string  str_err;
-
-
-        tt__VideoSourceConfiguration*  get_video_src_cnf(struct soap *soap) const;
-        tt__VideoEncoderConfiguration* get_video_enc_cfg(struct soap *soap) const;
-        tt__PTZConfiguration*          get_ptz_cfg(struct soap *soap) const;
 };
 
 

--- a/src/ServiceDevice.cpp
+++ b/src/ServiceDevice.cpp
@@ -123,7 +123,7 @@ int DeviceBindingService::GetSystemDateAndTime(_tds__GetSystemDateAndTime *tds__
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->DateTimeType      = tt__SetDateTimeType__Manual;
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->DaylightSavings   = tm->tm_isdst;
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->TimeZone          = soap_new_tt__TimeZone(this->soap);
-    tds__GetSystemDateAndTimeResponse.SystemDateAndTime->TimeZone->TZ      = tm->tm_zone;
+    tds__GetSystemDateAndTimeResponse.SystemDateAndTime->TimeZone->TZ      = "GMT0";
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->UTCDateTime       = soap_new_tt__DateTime(this->soap);
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->UTCDateTime->Time = soap_new_req_tt__Time(this->soap, tm->tm_hour, tm->tm_min  , tm->tm_sec );
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->UTCDateTime->Date = soap_new_req_tt__Date(this->soap, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday);

--- a/src/ServiceDevice.cpp
+++ b/src/ServiceDevice.cpp
@@ -11,6 +11,7 @@
 #include "soapDeviceBindingService.h"
 #include "ServiceContext.h"
 #include "smacros.h"
+#include "stools.h"
 
 
 
@@ -317,7 +318,13 @@ int DeviceBindingService::SetUser(_tds__SetUser *tds__SetUser, _tds__SetUserResp
 
 int DeviceBindingService::GetWsdlUrl(_tds__GetWsdlUrl *tds__GetWsdlUrl, _tds__GetWsdlUrlResponse &tds__GetWsdlUrlResponse)
 {
-    SOAP_EMPTY_HANDLER(tds__GetWsdlUrl, "Device");
+    UNUSED(tds__GetWsdlUrl);
+    DEBUG_MSG("Device: %s\n", __FUNCTION__);
+
+    std::string url = soap->endpoint;
+    tds__GetWsdlUrlResponse.WsdlUrl = url.c_str();
+
+    return SOAP_OK;
 }
 
 
@@ -360,6 +367,9 @@ int DeviceBindingService::GetCapabilities(_tds__GetCapabilities *tds__GetCapabil
             tds__GetCapabilitiesResponse.Capabilities->Media  = soap_new_tt__MediaCapabilities(this->soap);
             tds__GetCapabilitiesResponse.Capabilities->Media->XAddr = XAddr;
             tds__GetCapabilitiesResponse.Capabilities->Media->StreamingCapabilities = soap_new_tt__RealTimeStreamingCapabilities(this->soap);
+            tds__GetCapabilitiesResponse.Capabilities->Media->StreamingCapabilities->RTPMulticast = soap_new_ptr(soap, false);
+            tds__GetCapabilitiesResponse.Capabilities->Media->StreamingCapabilities->RTP_USCORETCP = soap_new_ptr(soap, false);
+            tds__GetCapabilitiesResponse.Capabilities->Media->StreamingCapabilities->RTP_USCORERTSP_USCORETCP = soap_new_ptr(soap, true);
         }
 
         if (ctx->get_ptz_node()->enable) {

--- a/src/ServiceMedia.cpp
+++ b/src/ServiceMedia.cpp
@@ -11,6 +11,7 @@
 #include "soapMediaBindingService.h"
 #include "ServiceContext.h"
 #include "smacros.h"
+#include "stools.h"
 
 
 
@@ -254,14 +255,40 @@ int MediaBindingService::DeleteProfile(_trt__DeleteProfile *trt__DeleteProfile, 
 
 int MediaBindingService::GetVideoSourceConfigurations(_trt__GetVideoSourceConfigurations *trt__GetVideoSourceConfigurations, _trt__GetVideoSourceConfigurationsResponse &trt__GetVideoSourceConfigurationsResponse)
 {
-    SOAP_EMPTY_HANDLER(trt__GetVideoSourceConfigurations, "Media");
+    UNUSED(trt__GetVideoSourceConfigurations);
+    DEBUG_MSG("Media: %s\n", __FUNCTION__);
+
+    ServiceContext* ctx = (ServiceContext*)this->soap->user;
+
+    auto profiles = ctx->get_profiles();
+
+    for( auto it = profiles.cbegin(); it != profiles.cend(); ++it )
+    {
+        tt__VideoSourceConfiguration *vsc = it->second.get_video_src_cnf(this->soap);
+        trt__GetVideoSourceConfigurationsResponse.Configurations.push_back(vsc);
+    }
+
+    return SOAP_OK;
 }
 
 
 
 int MediaBindingService::GetVideoEncoderConfigurations(_trt__GetVideoEncoderConfigurations *trt__GetVideoEncoderConfigurations, _trt__GetVideoEncoderConfigurationsResponse &trt__GetVideoEncoderConfigurationsResponse)
 {
-    SOAP_EMPTY_HANDLER(trt__GetVideoEncoderConfigurations, "Media");
+    UNUSED(trt__GetVideoEncoderConfigurations);
+    DEBUG_MSG("Media: %s\n", __FUNCTION__);
+
+    ServiceContext* ctx = (ServiceContext*)this->soap->user;
+
+    auto profiles = ctx->get_profiles();
+
+    for( auto it = profiles.cbegin(); it != profiles.cend(); ++it )
+    {
+        tt__VideoEncoderConfiguration *vec = it->second.get_video_enc_cfg(this->soap);
+        trt__GetVideoEncoderConfigurationsResponse.Configurations.push_back(vec);
+    }
+
+    return SOAP_OK;
 }
 
 
@@ -310,14 +337,44 @@ int MediaBindingService::GetAudioDecoderConfigurations(_trt__GetAudioDecoderConf
 
 int MediaBindingService::GetVideoSourceConfiguration(_trt__GetVideoSourceConfiguration *trt__GetVideoSourceConfiguration, _trt__GetVideoSourceConfigurationResponse &trt__GetVideoSourceConfigurationResponse)
 {
-    SOAP_EMPTY_HANDLER(trt__GetVideoSourceConfiguration, "Media");
+    DEBUG_MSG("Media: %s\n", __FUNCTION__);
+
+    ServiceContext* ctx = (ServiceContext*)this->soap->user;
+
+    auto profiles = ctx->get_profiles();
+
+    for( auto it = profiles.cbegin(); it != profiles.cend(); ++it )
+    {
+        if (trt__GetVideoSourceConfiguration->ConfigurationToken == it->second.get_video_src_cnf(this->soap)->token) {
+            tt__VideoSourceConfiguration *vsc = it->second.get_video_src_cnf(this->soap);
+            trt__GetVideoSourceConfigurationResponse.Configuration = vsc;
+            break;
+        }
+    }
+
+    return SOAP_OK;
 }
 
 
 
 int MediaBindingService::GetVideoEncoderConfiguration(_trt__GetVideoEncoderConfiguration *trt__GetVideoEncoderConfiguration, _trt__GetVideoEncoderConfigurationResponse &trt__GetVideoEncoderConfigurationResponse)
 {
-    SOAP_EMPTY_HANDLER(trt__GetVideoEncoderConfiguration, "Media");
+    DEBUG_MSG("Media: %s\n", __FUNCTION__);
+
+    ServiceContext* ctx = (ServiceContext*)this->soap->user;
+
+    auto profiles = ctx->get_profiles();
+
+    for( auto it = profiles.cbegin(); it != profiles.cend(); ++it )
+    {
+        if (trt__GetVideoEncoderConfiguration->ConfigurationToken == it->second.get_video_enc_cfg(this->soap)->token) {
+            tt__VideoEncoderConfiguration *vec = it->second.get_video_enc_cfg(this->soap);
+            trt__GetVideoEncoderConfigurationResponse.Configuration = vec;
+            break;
+        }
+    }
+
+    return SOAP_OK;
 }
 
 
@@ -527,7 +584,15 @@ int MediaBindingService::GetAudioDecoderConfigurationOptions(_trt__GetAudioDecod
 
 int MediaBindingService::GetGuaranteedNumberOfVideoEncoderInstances(_trt__GetGuaranteedNumberOfVideoEncoderInstances *trt__GetGuaranteedNumberOfVideoEncoderInstances, _trt__GetGuaranteedNumberOfVideoEncoderInstancesResponse &trt__GetGuaranteedNumberOfVideoEncoderInstancesResponse)
 {
-    SOAP_EMPTY_HANDLER(trt__GetGuaranteedNumberOfVideoEncoderInstances, "Media");
+    UNUSED(trt__GetGuaranteedNumberOfVideoEncoderInstances);
+    DEBUG_MSG("Media: %s\n", __FUNCTION__);
+
+    trt__GetGuaranteedNumberOfVideoEncoderInstancesResponse.TotalNumber = 3;
+    trt__GetGuaranteedNumberOfVideoEncoderInstancesResponse.JPEG = soap_new_ptr(soap, 0);
+    trt__GetGuaranteedNumberOfVideoEncoderInstancesResponse.H264 = soap_new_ptr(soap, 3);
+    trt__GetGuaranteedNumberOfVideoEncoderInstancesResponse.MPEG4 = soap_new_ptr(soap, 0);
+
+    return SOAP_OK;
 }
 
 


### PR DESCRIPTION
I added some properties to pass compatibility tests with onvif device test tool.
I also added the implementation for 6 functions:

- GetWsdlUrl
- GetVideoSourceConfigurations
- GetVideoEncoderConfigurations
- GetVideoSourceConfiguration
- GetVideoEncoderConfiguration
- GetGuaranteedNumberOfVideoEncoderInstances

To do this I moved

- tt__VideoSourceConfiguration*  get_video_src_cnf(struct soap *soap) const;
- tt__VideoEncoderConfiguration* get_video_enc_cfg(struct soap *soap) const;
- tt__PTZConfiguration*          get_ptz_cfg(struct soap *soap) const;

from private to public.

Finally, in the function GetGuaranteedNumberOfVideoEncoderInstances, I set 3 h264 instances as default.
