### PR TITLE
Fix timezone in GetSystemDateAndTime

### DIFF
--- a/src/ServiceDevice.cpp
+++ b/src/ServiceDevice.cpp
@@ -122,7 +122,7 @@ int DeviceBindingService::GetSystemDateAndTime(_tds__GetSystemDateAndTime *tds__
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->DateTimeType      = tt__SetDateTimeType__Manual;
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->DaylightSavings   = tm->tm_isdst;
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->TimeZone          = soap_new_tt__TimeZone(this->soap);
-    tds__GetSystemDateAndTimeResponse.SystemDateAndTime->TimeZone->TZ      = tm->tm_zone;
+    tds__GetSystemDateAndTimeResponse.SystemDateAndTime->TimeZone->TZ      = "GMT0";
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->UTCDateTime       = soap_new_tt__DateTime(this->soap);
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->UTCDateTime->Time = soap_new_req_tt__Time(this->soap, tm->tm_hour, tm->tm_min  , tm->tm_sec );
     tds__GetSystemDateAndTimeResponse.SystemDateAndTime->UTCDateTime->Date = soap_new_req_tt__Date(this->soap, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday);


### PR DESCRIPTION
With tm->tm_zone, onvif device test tool reports "Time zone format is not correct: Standard offset part format is not incorrect".
Changed to "GMT0" it's ok.
